### PR TITLE
Fix typo in site.conf

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -267,7 +267,7 @@ Willkommen zum Einrichtungsassistenten f&uuml;r deinen neuen Freifunk-Knoten f&u
 F&uuml;lle das folgende Formular deinen Vorstellungen
 entsprechend aus und sende es ab.
 ]],
-		msg_pubkey = [[,
+		msg_pubkey = [[
 Das ist der Schl&uuml;ssel deines Freifunkknotens zur Information. Der Knoten ist nun direkt nutzbar.
 
 Bitte vergiss nicht das Netzwerkkabel vom gelben LAN Port in den blauen WAN Port umzustecken.


### PR DESCRIPTION
Remove a ',' at a nonsensical position.