### PR TITLE
Add modules file to site directory

### DIFF
--- a/modules
+++ b/modules
@@ -1,0 +1,3 @@
+GLUON_SITE_FEEDS="ssidchanger"
+PACKAGES_SSIDCHANGER_REPO=https://github.com/ffac/gluon-ssid-changer.git
+PACKAGES_SSIDCHANGER_COMMIT=06bdf6fc6149af9cbb4564aac82cadd56a98a8b2


### PR DESCRIPTION
In addition to the global gluon modules file, there can be a site
specific modules file.

Using that, it's not necessary to manually edit the gluon modules file
to add the offline-ssid feature.