### PR TITLE
re-introduce (now empty) translation for gluon-config-mode:pubkey

### DIFF
--- a/i18n/de.po
+++ b/i18n/de.po
@@ -17,6 +17,8 @@ msgstr ""
 "entsprechend aus und sende es ab."
 
 
+msgid "gluon-config-mode:pubkey"
+msgstr ""
 
 msgid "gluon-config-mode:reboot"
 msgstr ""

--- a/i18n/en.po
+++ b/i18n/en.po
@@ -16,6 +16,8 @@ msgstr ""
 "Please fill out the following form and transmit it."
 
 
+msgid "gluon-config-mode:pubkey"
+msgstr ""
 
 msgid "gluon-config-mode:reboot"
 msgstr ""


### PR DESCRIPTION
If the msgid is not found in the po file at all, the msgid itself
will be shown on the web page. This would lead to the following output:

"Your node's setup is now complete.
gluon-config-mode:pubkey

The node is currently rebooting and will try to connect to other nearby
Freifunk nodes afterwards. [...]"