### PR TITLE
add package ffac-status-page-api

### DIFF
--- a/modules
+++ b/modules
@@ -1,4 +1,8 @@
-GLUON_SITE_FEEDS="ssidchanger"
+GLUON_SITE_FEEDS="ssidchanger ffac"
 PACKAGES_SSIDCHANGER_REPO=https://github.com/ffac/gluon-ssid-changer.git
 PACKAGES_SSIDCHANGER_COMMIT=1146ff354ff0bb99a100d6b067fc410068e7521d
 PACKAGES_SSIDCHANGER_BRANCH=chaos-calmer
+
+PACKAGES_FFAC_REPO=https://github.com/ffac/ffac-status-page-api.git
+PACKAGES_FFAC_COMMIT=34ca3da5abdf41f7d0761149f5a1bc86f722668b
+PACKAGES_FFAC_BRANCH=master

--- a/site.mk
+++ b/site.mk
@@ -27,6 +27,7 @@ GLUON_SITE_PACKAGES := \
 	gluon-mesh-vpn-fastd \
 	gluon-radvd \
 	gluon-setup-mode \
+	ffac-status-page-api \
 	gluon-status-page \
 	iwinfo \
 	iptables \


### PR DESCRIPTION
Ich bin dafür das so aufzunehmen.

Es ist zwar kein sonderlich starker Schutz der Kontaktdaten, aber immerhin behalten wir den Status quo bei.

Bei gluon entwickelt sich die Diskussion derzeit in eine gute Richtung, die Übertragung der Kontaktdaten mittels Verschlüsselung auf Basis der fastd Keys.