### PR TITLE
Fix 5GHz BSSID - again

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -99,7 +99,7 @@
 		},
 		ibss = {
 			ssid = 'wifimesh-a-ac',
-			bssid = 'CA:FF:52:FF:AC:52',
+			bssid = 'CA:FE:52:FF:AC:52',
 			mcast_rate = 12000,
 		},
 --		mesh = {

--- a/site.conf
+++ b/site.conf
@@ -99,6 +99,8 @@
 		},
 		ibss = {
 			ssid = 'wifimesh-a-ac',
+			-- ACHTUNG: Subtile Unterschiede zur 2.4GHz bssid beachten!
+			-- CA:F*E*:*52*:FF:AC:*52*
 			bssid = 'CA:FE:52:FF:AC:52',
 			mcast_rate = 12000,
 		},


### PR DESCRIPTION
Also ich vor rund einem Jahr die initalen Mesh BSSID erstellt habe ist habe ich sie versehentlich nicht konsistent erstellt.

2.4GHz: CA:FF:24:FF:AC:24
5.2GHz: CA:FE:52:FF:AC:52

Seit dem ergab sich keine Gelegenheit das anzupassen, da es immer ein Inkompatibilität im Mesh bedeutet hätte.

Eine Anpassung lohnt sich nicht mehr, mit 802.11s mesh wird die BSSID nicht mehr fix gesetzt.