### PR TITLE
remove gluon-alfred

### DIFF
--- a/site.mk
+++ b/site.mk
@@ -6,7 +6,6 @@
 
 GLUON_SITE_PACKAGES := \
 	gluon-mesh-batman-adv-14 \
-	gluon-alfred \
 	gluon-respondd \
 	gluon-autoupdater \
 	gluon-config-mode-core \


### PR DESCRIPTION
Durch Umstieg auf Hopglass wird Alfred nicht mehr benötigt