### PR TITLE
add "GLUON_REGION ?= eu" to site.mk

### DIFF
--- a/site.mk
+++ b/site.mk
@@ -137,5 +137,8 @@ GLUON_RELEASE ?= $(DEFAULT_GLUON_RELEASE)
 # Default priority for updates.
 GLUON_PRIORITY ?= 0
 
+# Region code required for some images; supported values: us eu
+GLUON_REGION ?= eu
+
 # Languages to include
 GLUON_LANGS ?= en de


### PR DESCRIPTION
"TP-Link has started providing US- and EU-specific firmwares for the
Archer C7 v2. To generate Gluon images installable from these new
firmwares, the GLUON_REGION variable must be set to eu or us in site.mk
or on the make command line (the images will still be installable from
all old firmwares without region codes)."

(from https://gluon.readthedocs.io/en/v2016.1.6/releases/v2016.1.6.html)