### PR TITLE
i18n: escape 'hostname'

### DIFF
--- a/i18n/de.po
+++ b/i18n/de.po
@@ -20,7 +20,7 @@ msgid "gluon-config-mode:pubkey"
 msgstr ""
 "<p>Bitte stecke nun das Netzwerkkabel vom (meist gelben) LAN Port in den (meist blauen) WAN Port deines Routers.</p>"
 "<p>Dies ist der öffentliche Schlüssel deines Freifunk-Knotens. Wenn du nicht weißt, worum es sich dabei handelt, kannst du ihn ignorieren. Wer sich auskennt kann damit dafür sorgen, dass sich der neue Freifunk Knoten von Anfang an zum richtigen Segment unseres Netzes verbindet.</p>"
-"Dabei hilft auch der Knotenname: (<em><%=hostname%></em>) und die MAC-Adresse: (<em><%=sysconfig.primary_mac%></em>)"
+"Dabei hilft auch der Knotenname: (<em><%=escape(hostname)%></em>) und die MAC-Adresse: (<em><%=sysconfig.primary_mac%></em>)"
 "<p>Dein öffentlicher Schlüssel: <em><%=pubkey%></em></p>"
 
 msgid "gluon-config-mode:reboot"

--- a/i18n/en.po
+++ b/i18n/en.po
@@ -20,7 +20,7 @@ msgstr ""
 "<p>Please remember to move the network cable form the yellow lan to the blue wan port.</p>"
 "<p>This is your Freifunk node's public key, you do not need to do anything with it.</p>"
 "<p>It is possible to use this key to place your node in the right network segment form its first connection, here are additional information:</p>"
-"<p>The node's name (<em><%=hostname%></em>) and MAC (<em><%=sysconfig.primary_mac%></em>).</p>"
+"<p>The node's name (<em><%=escape(hostname)%></em>) and MAC (<em><%=sysconfig.primary_mac%></em>).</p>"
 "<p>Your public Key: <em><%=pubkey%></em></p>"
 
 


### PR DESCRIPTION
"As the hostname field may now contain an arbitrary UTF-8 string,
escaping must be added."
https://gluon.readthedocs.io/en/latest/releases/v2016.2.html