### PR TITLE
Redundante Domains fürs Update

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -286,8 +286,9 @@
 			stable = {
 				name = 'stable',
 				mirrors = {
-                                        'http://0.updates.freifunk-aachen.de/stable/sysupgrade',
-                                        'http://1.updates.freifunk-aachen.de/stable/sysupgrade',
+                                        'http://updates.freifunk-aachen.de/stable/sysupgrade',
+                                        'http://updates.ffac.rocks/stable/sysupgrade',
+					'http://updates.aachen.freifunk.net/stable/sysupgrade',
 				},
 				good_signatures = 4,
 				pubkeys = {
@@ -303,8 +304,9 @@
 			beta = {
 				name = 'beta',
 				mirrors = {
-                                        'http://0.updates.freifunk-aachen.de/beta/sysupgrade',
-                                        'http://1.updates.freifunk-aachen.de/beta/sysupgrade',
+                                        'http://updates.freifunk-aachen.de/stable/sysupgrade',
+                                        'http://updates.ffac.rocks/stable/sysupgrade',
+					'http://updates.aachen.freifunk.net/stable/sysupgrade',
 					},
 				good_signatures = 3,
 				pubkeys = {
@@ -320,9 +322,10 @@
                         experimental = {
                                 name = 'experimental',
                                 mirrors = {
-                                        'http://0.updates.freifunk-aachen.de/experimental/sysupgrade',
-                                        'http://1.updates.freifunk-aachen.de/experimental/sysupgrade',
-				        },
+                                        'http://updates.freifunk-aachen.de/stable/sysupgrade',
+                                        'http://updates.ffac.rocks/stable/sysupgrade',
+					'http://updates.aachen.freifunk.net/stable/sysupgrade',
+					},
                                 good_signatures = 2,
                                 pubkeys = {
 					'e1505aadd3c5674a93ff2c8596b2cb2d857b068b18f9a398a182b003a5e5040b', -- Bob (Build Server @skydisk)

--- a/site.conf
+++ b/site.conf
@@ -288,7 +288,7 @@
 				mirrors = {
                                         'http://updates.freifunk-aachen.de/stable/sysupgrade',
                                         'http://updates.ffac.rocks/stable/sysupgrade',
-					'http://updates.aachen.freifunk.net/stable/sysupgrade',
+                                        'http://updates.aachen.freifunk.net/stable/sysupgrade',
 				},
 				good_signatures = 4,
 				pubkeys = {
@@ -304,9 +304,9 @@
 			beta = {
 				name = 'beta',
 				mirrors = {
-                                        'http://updates.freifunk-aachen.de/stable/sysupgrade',
-                                        'http://updates.ffac.rocks/stable/sysupgrade',
-					'http://updates.aachen.freifunk.net/stable/sysupgrade',
+                                        'http://updates.freifunk-aachen.de/beta/sysupgrade',
+                                        'http://updates.ffac.rocks/beta/sysupgrade',
+                                        'http://updates.aachen.freifunk.net/beta/sysupgrade',
 					},
 				good_signatures = 3,
 				pubkeys = {
@@ -322,9 +322,9 @@
                         experimental = {
                                 name = 'experimental',
                                 mirrors = {
-                                        'http://updates.freifunk-aachen.de/stable/sysupgrade',
-                                        'http://updates.ffac.rocks/stable/sysupgrade',
-					'http://updates.aachen.freifunk.net/stable/sysupgrade',
+                                        'http://updates.freifunk-aachen.de/experimental/sysupgrade',
+                                        'http://updates.ffac.rocks/experimental/sysupgrade',
+                                        'http://updates.aachen.freifunk.net/experimental/sysupgrade',
 					},
                                 good_signatures = 2,
                                 pubkeys = {


### PR DESCRIPTION
Wir müssen um sinnvoll sicherzustellen, dass nur 2016.2.7 Knoten auf 2017.x updaten in irgendeiner Form die Update Server ändern, das können wir auch direkt als Gelegenheit nutzen Redundanz bei den Domains einzuführen.

Dabei dann auch direkt eingekürzt, da wir nicht mehr durchnummerieren müssen.