### PR TITLE
Include ACPI button support on x86-{generic,64,geode}

### DIFF
--- a/site.mk
+++ b/site.mk
@@ -111,7 +111,8 @@ GLUON_SITE_PACKAGES += \
         kmod-forcedeth \
         kmod-8139too \
 	kmod-atl2 \
-	kmod-igb
+	kmod-igb \
+	kmod-button-hotplug
 endif
 
 ifeq ($(GLUON_TARGET),x86-64)
@@ -128,7 +129,8 @@ GLUON_SITE_PACKAGES += \
         kmod-forcedeth \
         kmod-8139too \
 	kmod-atl2 \
-	kmod-igb
+	kmod-igb \
+	kmod-button-hotplug
 endif
 
 ifeq ($(GLUON_TARGET),x86-geode)
@@ -145,7 +147,8 @@ GLUON_SITE_PACKAGES += \
         kmod-forcedeth \
         kmod-8139too \
         kmod-atl2 \
-        kmod-igb
+        kmod-igb \
+	kmod-button-hotplug
 endif
 
 # Add offline ssid, network drivers and usb stuff to raspberry and banana pi images


### PR DESCRIPTION
I created this PR after having to reinstall kmod-button-hotplug for the 3rd or 4th time after it was removed by sysupgrade when installing new firmware versions. I've not managed to find a place where to put packages that should survive sysupgrade (or get auto reinstalled). I think this is especially useful for offloader VMs as without this they don't respond to simulated power button presses sent by the hypervisor when asking the offloader VM to stop.

If this is not the right place in the file or file at all for this: Where should this go?
Do you think it's a good idea to include this on x86 by default?