### PR TITLE
Revert "respondd-module-airtime nicht kompatibel mit yanic"

### DIFF
--- a/site.mk
+++ b/site.mk
@@ -44,21 +44,25 @@ GLUON_SITE_PACKAGES := \
 # add offline ssid only if the target has wifi device
 ifeq ($(GLUON_TARGET),ar71xx-generic)
 GLUON_SITE_PACKAGES += \
+	respondd-module-airtime \
 	gluon-ssid-changer 
 endif
 
 ifeq ($(GLUON_TARGET),ar71xx-mikrotik)
 GLUON_SITE_PACKAGES += \
+	respondd-module-airtime \
 	gluon-ssid-changer
 endif
 
 ifeq ($(GLUON_TARGET),ar71xx-nand)
 GLUON_SITE_PACKAGES += \
+	respondd-module-airtime \
 	gluon-ssid-changer
 endif
 
 ifeq ($(GLUON_TARGET),ar71xx-tiny)
 GLUON_SITE_PACKAGES += \
+	respondd-module-airtime \
 	gluon-ssid-changer
 endif
 
@@ -69,21 +73,25 @@ endif
 
 ifeq ($(GLUON_TARGET),ipq806x)
 GLUON_SITE_PACKAGES += \
+	respondd-module-airtime \
         gluon-ssid-changer
 endif
 
 ifeq ($(GLUON_TARGET),mpc85xx-generic)
 GLUON_SITE_PACKAGES += \
+	respondd-module-airtime \
 	gluon-ssid-changer
 endif
 
 ifeq ($(GLUON_TARGET),mvebu)
 GLUON_SITE_PACKAGES += \
+	respondd-module-airtime \
         gluon-ssid-changer
 endif
 
 ifeq ($(GLUON_TARGET),ramips-mt7620)
 GLUON_SITE_PACKAGES += \
+	respondd-module-airtime \
         gluon-ssid-changer
 endif
 
@@ -99,16 +107,19 @@ endif
 
 ifeq ($(GLUON_TARGET),ramips-mt7628)
 GLUON_SITE_PACKAGES += \
+	respondd-module-airtime \
         gluon-ssid-changer
 endif
 
 ifeq ($(GLUON_TARGET),ramips-rt305x)
 GLUON_SITE_PACKAGES += \
+	respondd-module-airtime \
 	gluon-ssid-changer
 endif
 
 ifeq ($(GLUON_TARGET),sunxi-cortexa7)
 GLUON_SITE_PACKAGES += \
+	respondd-module-airtime \
 	gluon-ssid-changer
 endif
 
@@ -171,6 +182,7 @@ endif
 
 ifeq ($(GLUON_TARGET),brcm2708-bcm2708)
 GLUON_SITE_PACKAGES += \
+	respondd-module-airtime \
         gluon-ssid-changer \
         kmod-usb-core \
         kmod-usb2 \
@@ -182,6 +194,7 @@ endif
 
 ifeq ($(GLUON_TARGET),brcm2708-bcm2709)
 GLUON_SITE_PACKAGES += \
+	respondd-module-airtime \
         gluon-ssid-changer \
         kmod-usb-core \
         kmod-usb2 \
@@ -193,6 +206,7 @@ endif
 
 ifeq ($(GLUON_TARGET),brcm2708-bcm2710)
 GLUON_SITE_PACKAGES += \
+	respondd-module-airtime \
         gluon-ssid-changer \
         kmod-usb-core \
         kmod-usb2 \
@@ -204,6 +218,7 @@ endif
 
 ifeq ($(GLUON_TARGET),sunxi)
 GLUON_SITE_PACKAGES += \
+	respondd-module-airtime \
         gluon-ssid-changer \
         kmod-usb-core \
         kmod-usb2 \


### PR DESCRIPTION
This reverts commit 19e14a123a5bc1d8defaf812dedf07d2da567242.

The incompatibility cited in the commit message comes from bug https://github.com/FreifunkBremen/yanic/issues/143 in yanic, which is already fixed by https://github.com/FreifunkBremen/yanic/commit/2697d4c228262c46eefd5c8b912ab8c686c6eab7