### PR TITLE
Remove invalid config option from site.conf

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -303,7 +303,6 @@
 	]]
 	autoupdater = {
 		branch = 'stable',
-		enabled = 1,
 		branches = {
 			stable = {
 				name = 'stable',


### PR DESCRIPTION
The only way to enable the autoupdater by default is setting GLUON_BRANCH when building the image.
There is no autoupdater.enabled option in site.conf with the same effect.