### PR TITLE
configure v2018.2.x specific upgrade path

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -307,9 +307,9 @@
 			stable = {
 				name = 'stable',
 				mirrors = {
-                                        'http://updates.freifunk-aachen.de/stable/sysupgrade',
-                                        'http://updates.ffac.rocks/stable/sysupgrade',
-                                        'http://updates.aachen.freifunk.net/stable/sysupgrade',
+                                        'http://updates.freifunk-aachen.de/from-2018.2.x/stable/sysupgrade',
+                                        'http://updates.ffac.rocks/from-2018.2.x/stable/sysupgrade',
+                                        'http://updates.aachen.freifunk.net/from-2018.2.x/stable/sysupgrade',
 				},
 				good_signatures = 4,
 				pubkeys = {
@@ -326,9 +326,9 @@
 			beta = {
 				name = 'beta',
 				mirrors = {
-                                        'http://updates.freifunk-aachen.de/beta/sysupgrade',
-                                        'http://updates.ffac.rocks/beta/sysupgrade',
-                                        'http://updates.aachen.freifunk.net/beta/sysupgrade',
+                                        'http://updates.freifunk-aachen.de/from-2018.2.x/beta/sysupgrade',
+                                        'http://updates.ffac.rocks/from-2018.2.x/beta/sysupgrade',
+                                        'http://updates.aachen.freifunk.net/from-2018.2.x/beta/sysupgrade',
 				},
 				good_signatures = 3,
 				pubkeys = {
@@ -345,9 +345,9 @@
                         experimental = {
                                 name = 'experimental',
                                 mirrors = {
-                                        'http://updates.freifunk-aachen.de/experimental/sysupgrade',
-                                        'http://updates.ffac.rocks/experimental/sysupgrade',
-                                        'http://updates.aachen.freifunk.net/experimental/sysupgrade',
+                                        'http://updates.freifunk-aachen.de/from-2018.2.x/experimental/sysupgrade',
+                                        'http://updates.ffac.rocks/from-2018.2.x/experimental/sysupgrade',
+                                        'http://updates.aachen.freifunk.net/from-2018.2.x/experimental/sysupgrade',
 				},
                                 good_signatures = 2,
                                 pubkeys = {


### PR DESCRIPTION
to stay consistent with #61 

This allows to provide a intermediate upgrade for firmware based on v2018.2.x