### PR TITLE
Updated gluon to 2021.1 as well as site specifc config

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -2,7 +2,7 @@
 	hostname_prefix = 'ffac-',
 	site_name = 'Freifunk Rheinland - Region Aachen',
 	site_code = 'ffac',
-    domain_seed = 'fcd2bb830c677865c60459899facdb630a9c09e26b72d995451c4feb9b337e6d',
+	domain_seed = 'fcd2bb830c677865c60459899facdb630a9c09e26b72d995451c4feb9b337e6d',
 
 	opkg = {
 		extra = {
@@ -177,18 +177,18 @@
 			stable = {
 				name = 'stable',
 				mirrors = {
-                    'http://updates.freifunk-aachen.de/from-2019.1.x/stable/sysupgrade',
-                    'http://updates.ffac.rocks/from-2019.1.x/stable/sysupgrade',
-                    'http://updates.aachen.freifunk.net/from-2019.1.x/stable/sysupgrade',
+					'http://updates.freifunk-aachen.de/from-2019.1.x/stable/sysupgrade',
+					'http://updates.ffac.rocks/from-2019.1.x/stable/sysupgrade',
+					'http://updates.aachen.freifunk.net/from-2019.1.x/stable/sysupgrade',
 				},
 				good_signatures = 4,
 				pubkeys = {
 					'e1505aadd3c5674a93ff2c8596b2cb2d857b068b18f9a398a182b003a5e5040b', -- Bob (Build Server @skydisk)
 					'b34dc4f34a5a6c588f6ac41736edd1195d9f5e949f913d4cc7a4777ebbf22c9c', -- MrMM
 					'd6a35069e60afad2f4554d6609c0934e478e264e7cfbd131afeac66ba745dc02', -- Shiva
-                    '5bdb75b8f2f290453933975ba772b94596a5dae5091a1e638d96e053247cf404', -- Monty
-                    'fcdc42af066d65fb655ab6d6f4709507dd29a0d38732bf60b3cbbdb1be6f7d24', -- Jannic
-                    '8672f3f07594d0b078780470f416580139ca4cf7c0984aeeb718abdbe2d14196', -- Sirius
+					'5bdb75b8f2f290453933975ba772b94596a5dae5091a1e638d96e053247cf404', -- Monty
+					'fcdc42af066d65fb655ab6d6f4709507dd29a0d38732bf60b3cbbdb1be6f7d24', -- Jannic
+					'8672f3f07594d0b078780470f416580139ca4cf7c0984aeeb718abdbe2d14196', -- Sirius
 					'342522f118b92ebeb5a8c9c9a2269faa886a14a798190fe5730cfff513a79dd3', -- vegms
 					'f5790bb64dd695f5f87469c47ecda11e218a35f5da807367110d1cb6354eb005', -- Sellerie
 				},
@@ -196,41 +196,41 @@
 			beta = {
 				name = 'beta',
 				mirrors = {
-                    'http://updates.freifunk-aachen.de/from-2019.1.x/beta/sysupgrade',
-                    'http://updates.ffac.rocks/from-2019.1.x/beta/sysupgrade',
-                    'http://updates.aachen.freifunk.net/from-2019.1.x/beta/sysupgrade',
+					'http://updates.freifunk-aachen.de/from-2019.1.x/beta/sysupgrade',
+					'http://updates.ffac.rocks/from-2019.1.x/beta/sysupgrade',
+					'http://updates.aachen.freifunk.net/from-2019.1.x/beta/sysupgrade',
 				},
 				good_signatures = 3,
 				pubkeys = {
 					'e1505aadd3c5674a93ff2c8596b2cb2d857b068b18f9a398a182b003a5e5040b', -- Bob (Build Server @skydisk)
 					'b34dc4f34a5a6c588f6ac41736edd1195d9f5e949f913d4cc7a4777ebbf22c9c', -- MrMM
 					'd6a35069e60afad2f4554d6609c0934e478e264e7cfbd131afeac66ba745dc02', -- Shiva
-                    '5bdb75b8f2f290453933975ba772b94596a5dae5091a1e638d96e053247cf404', -- Monty
-                    'fcdc42af066d65fb655ab6d6f4709507dd29a0d38732bf60b3cbbdb1be6f7d24', -- Jannic
-                    '8672f3f07594d0b078780470f416580139ca4cf7c0984aeeb718abdbe2d14196', -- Sirius
+					'5bdb75b8f2f290453933975ba772b94596a5dae5091a1e638d96e053247cf404', -- Monty
+					'fcdc42af066d65fb655ab6d6f4709507dd29a0d38732bf60b3cbbdb1be6f7d24', -- Jannic
+					'8672f3f07594d0b078780470f416580139ca4cf7c0984aeeb718abdbe2d14196', -- Sirius
 					'342522f118b92ebeb5a8c9c9a2269faa886a14a798190fe5730cfff513a79dd3', -- vegms
 					'f5790bb64dd695f5f87469c47ecda11e218a35f5da807367110d1cb6354eb005', -- Sellerie
 				},
 			},
-            experimental = {
-                name = 'experimental',
-                mirrors = {
-                    'http://updates.freifunk-aachen.de/from-2019.1.x/experimental/sysupgrade',
-                    'http://updates.ffac.rocks/from-2019.1.x/experimental/sysupgrade',
-                    'http://updates.aachen.freifunk.net/from-2019.1.x/experimental/sysupgrade',
+			experimental = {
+				name = 'experimental',
+				mirrors = {
+					'http://updates.freifunk-aachen.de/from-2019.1.x/experimental/sysupgrade',
+					'http://updates.ffac.rocks/from-2019.1.x/experimental/sysupgrade',
+					'http://updates.aachen.freifunk.net/from-2019.1.x/experimental/sysupgrade',
 				},
-                good_signatures = 2,
-                pubkeys = {
+				good_signatures = 2,
+				pubkeys = {
 					'e1505aadd3c5674a93ff2c8596b2cb2d857b068b18f9a398a182b003a5e5040b', -- Bob (Build Server @skydisk)
 					'b34dc4f34a5a6c588f6ac41736edd1195d9f5e949f913d4cc7a4777ebbf22c9c', -- MrMM
 					'd6a35069e60afad2f4554d6609c0934e478e264e7cfbd131afeac66ba745dc02', -- Shiva
-                    '5bdb75b8f2f290453933975ba772b94596a5dae5091a1e638d96e053247cf404', -- Monty
-                    'fcdc42af066d65fb655ab6d6f4709507dd29a0d38732bf60b3cbbdb1be6f7d24', -- Jannic
-                    '8672f3f07594d0b078780470f416580139ca4cf7c0984aeeb718abdbe2d14196', -- Sirius
+					'5bdb75b8f2f290453933975ba772b94596a5dae5091a1e638d96e053247cf404', -- Monty
+					'fcdc42af066d65fb655ab6d6f4709507dd29a0d38732bf60b3cbbdb1be6f7d24', -- Jannic
+					'8672f3f07594d0b078780470f416580139ca4cf7c0984aeeb718abdbe2d14196', -- Sirius
 					'342522f118b92ebeb5a8c9c9a2269faa886a14a798190fe5730cfff513a79dd3', -- vegms
 					'f5790bb64dd695f5f87469c47ecda11e218a35f5da807367110d1cb6354eb005', -- Sellerie
-                },
-            },
+				},
+			},
 		},
 	},
 
@@ -255,20 +255,20 @@
  		skip = false,
  	},
 
-    ssid_changer = {
-        enabled = true,
-        switch_timeframe = 1,           -- only once every timeframe (in minutes) the SSID will change to OFFLINE 
-                                        -- set to 1440 to change once a day
-                                        -- set to 1 minute to change every time the router gets offline
-        first = 2,                      -- the first few minutes directly after reboot within which an Offline-SSID always may be activated
-        prefix = 'FF_Offline_',         -- use something short to leave space for the nodename (no '~' allowed!)
-        suffix = 'nodename',            -- generate the SSID with either 'nodename', 'mac' or to use only the prefix: 'none'
-        tq_limit_enabled = false,       -- if false, the offline SSID will only be set if there is no gateway reacheable
-                                        -- upper and lower limit to turn the offline_ssid on and off
-                                        -- in-between these two values the SSID will never be changed to prevent it from toggeling every minute.
-        tq_limit_max = 55,              -- upper limit, above that the online SSID will be used
-        tq_limit_min = 45,              -- lower limit, below that the offline SSID will be used
-    },
+	ssid_changer = {
+		enabled = true,
+		switch_timeframe = 1,           -- only once every timeframe (in minutes) the SSID will change to OFFLINE 
+										-- set to 1440 to change once a day
+										-- set to 1 minute to change every time the router gets offline
+		first = 2,                      -- the first few minutes directly after reboot within which an Offline-SSID always may be activated
+		prefix = 'FF_Offline_',         -- use something short to leave space for the nodename (no '~' allowed!)
+		suffix = 'nodename',            -- generate the SSID with either 'nodename', 'mac' or to use only the prefix: 'none'
+		tq_limit_enabled = false,       -- if false, the offline SSID will only be set if there is no gateway reacheable
+										-- upper and lower limit to turn the offline_ssid on and off
+										-- in-between these two values the SSID will never be changed to prevent it from toggeling every minute.
+		tq_limit_max = 55,              -- upper limit, above that the online SSID will be used
+		tq_limit_min = 45,              -- lower limit, below that the offline SSID will be used
+	},
 }
 
 -- /* vi: set ft=lua: */

--- a/site.conf
+++ b/site.conf
@@ -1,68 +1,22 @@
 {
-	--[[	Community settings
-	hostname_prefix:	Nodename prefix
-		freifunk-abcdef123456 (hex-part is generated from node's MAC address)
-	site_name:			Name of your community
-	site_code:			Shortcode of your community
-	]]
 	hostname_prefix = 'ffac-',
-	site_name = 'Freifunk Rheinland - Regio Aachen',
+	site_name = 'Freifunk Rheinland - Region Aachen',
 	site_code = 'ffac',
-
-        -- 32 bytes of random data, encoded in hexacimal
-        -- Must be the same of all nodes in one mesh domain
-        -- Can be generated using: echo $(hexdump -n 32 -e '1/1 "%02x"' </dev/urandom)
-        domain_seed = 'fcd2bb830c677865c60459899facdb630a9c09e26b72d995451c4feb9b337e6d',
+    domain_seed = 'fcd2bb830c677865c60459899facdb630a9c09e26b72d995451c4feb9b337e6d',
 
 	opkg = {
 		extra = {
 			modules = 'http://opkg.ffac.rocks/modules/gluon-%GS-%GR/%S',
-			},
+		},
 	},
-
-	--[[	General network settings
-	prefix4:			IPv4 range of your community
-	prefix6:			IPv6 range of your community
-		is also required for radvd
-
-	We use our global unicast block  2a03:2260:114::/48 for IP routing. This prefix is ONLY used for the next node feature and is used in multiple layer 2 network segments.
-	]]
 	prefix6 = 'fdac::/64',
-
-
-	--[[	NTP settings
-			Synchronize the time of the nodes
-	timezone:			Timezone of your community
-		http://wiki.openwrt.org/doc/uci/system#time.zones
-	ntp_servers:		List of NTP-Servers to query. You can use any public and/or your private NTP-Servers of your community.
-		http://www.pool.ntp.org/zone/de
-	#############
-	# NOTE: http://news.ntppool.org/2013/06/ipv6-monitoring-problems-for-g.html
-	# > As you might know only "2.pool.ntp.org" (and 2.debian.pool.ntp.org, etc)
-	# > returns AAAA records currently.
-	#############
-	 ]]
 	timezone = 'CET-1CEST,M3.5.0,M10.5.0/3',
 	ntp_servers = {
 			'a.ntp.ffac.rocks',
 			'ntp-b.aachen.freifunk.net',
-			'2.openwrt.pool.ntp.org',
+			'0.openwrt.pool.ntp.org',
 	},
 
-	--[[	Wireless settings
-	regdom:			IEEE 802.11 Regulatory Domain
-		http://en.wikipedia.org/wiki/IEEE_802.11#Regulatory_domains_and_legal_compliance
-	wifi24:			Wifi settings for 2.4 GHz frequency devices
-	wifi5:			Wifi settings for 5 GHz frequency devices
-		sub
-	ssid:			Wifi name shown to the user (We recommend %site_code%.freifunk.net)
-	channel:		Wifi channel to use
-	mesh_ssid:		SSID of the mesh-interface, only used between nodes
-	mesh_bssid:		BSSID of the mesh-interface
-	                        The supplied default of ff:ff:ff:ff:ff:ff will not work.
-	                        You'll need to replace it with randomly generated, non-broadcast BSSID!
-	mesh_mcast_rate:	multicast rate of the mesh-interface
-	]]
 	regdom = 'DE',
 
 	wifi24 = {
@@ -70,15 +24,10 @@
 		ap = {
 			ssid = 'Freifunk',
 		},
-		ibss = {
-			ssid = 'wifimesh-g-ac',
-			bssid = 'CA:FF:24:FF:AC:24',
+		mesh = {
+			id = 'ffac-mesh',
 			mcast_rate = 12000,
 		},
---	mesh = {
---		id = 'ffac-mesh',
---		mcast_rate = 12000,
---	},
 	},
 
 	wifi5 = {
@@ -108,39 +57,10 @@
 	mesh_on_wan = false,
 	poe_passthrough = true,
 
-	--[[	Next-Node
-	next_node:		Howto reach the node you are currently connected to
-			The node will always be reachable at that address, and it's the same on all nodes. Because next_node packets are redirected within the node itself, there will be no conflicts.
-		sub
-	ip4:			IPv4 Address to use (optional)
-	ip6:			IPv6 Address to use
-	mac:			MAC Address to use
-		(TODO: What is the purpose of this MAC-Address here?)
-	]]
 	next_node = {
 		ip6 = 'fdac::ac',
 		mac = 'ac:41:95:40:f7:dc',
 	},
-
-
-	--[[	Gateway settings
-	fastd_mesh_vpn:	fastd vpn settings
-		https://projects.universe-factory.net/projects/fastd/wiki/User_manual
-		sub
-	methods:		encryption algorithms to use
-		https://projects.universe-factory.net/projects/fastd/wiki/Methods
-		When multiple method statements are given, the first one has the highest preference.
-	mtu:			package size
-	backbone:		fastd vpn gateways of your community
-		sub
-	limit:			Number of gateways each node connects to
-		On startup, each node tries to connect to every gateway, and then chooses the number of 'limit' fastest gateways it could reach
-	peers:			Gateways
-		sub sub
-	key:			public fastd key of your gateway
-		https://github.com/tcatm/ecdsautils
-	remotes:		List of fastd configuration strings to connect to your gateway server
-	]]
 	mesh_vpn = {
 		mtu = 1406,
 		fastd = {
@@ -251,42 +171,24 @@
 		},
 	},
 
-	--[[	Autoupdater settings
-	branch:			Automatically update to this branch
-	branches:		Available branches your community is publishing
-		sub sub
-	name:			Name of branch (is used when compiling images)
-	mirrors:		List of urls where to find the firmware
-		just serve the images on port 80 via http. a simple apache file-listing is enough.
-		see: http://luebeck.freifunk.net/firmware/
-	probability:	How often should a node search for updates
-		1.0 - perform an update every hour
-		0.5 - on average, perform an update every two hours
-		0.0 - inhibit any automatic updates
-	good_signatures:	How many signatures should be valid so the node decides to upgrade itself
-	pubkeys:		public keys by developers used in manifest file of branch
-		manifest file - see gluon readme
-		$ make manifest GLUON_BRANCH=mybranch
-		$ contrib/sign.sh $SECRETKEY.file images/sysupgrade/manifest
-	]]
 	autoupdater = {
 		branch = 'stable',
 		branches = {
 			stable = {
 				name = 'stable',
 				mirrors = {
-                                        'http://updates.freifunk-aachen.de/from-2019.1.x/stable/sysupgrade',
-                                        'http://updates.ffac.rocks/from-2019.1.x/stable/sysupgrade',
-                                        'http://updates.aachen.freifunk.net/from-2019.1.x/stable/sysupgrade',
+                    'http://updates.freifunk-aachen.de/from-2019.1.x/stable/sysupgrade',
+                    'http://updates.ffac.rocks/from-2019.1.x/stable/sysupgrade',
+                    'http://updates.aachen.freifunk.net/from-2019.1.x/stable/sysupgrade',
 				},
 				good_signatures = 4,
 				pubkeys = {
 					'e1505aadd3c5674a93ff2c8596b2cb2d857b068b18f9a398a182b003a5e5040b', -- Bob (Build Server @skydisk)
 					'b34dc4f34a5a6c588f6ac41736edd1195d9f5e949f913d4cc7a4777ebbf22c9c', -- MrMM
 					'd6a35069e60afad2f4554d6609c0934e478e264e7cfbd131afeac66ba745dc02', -- Shiva
-                                        '5bdb75b8f2f290453933975ba772b94596a5dae5091a1e638d96e053247cf404', -- Monty
-                                        'fcdc42af066d65fb655ab6d6f4709507dd29a0d38732bf60b3cbbdb1be6f7d24', -- Jannic
-                                        '8672f3f07594d0b078780470f416580139ca4cf7c0984aeeb718abdbe2d14196', -- Sirius
+                    '5bdb75b8f2f290453933975ba772b94596a5dae5091a1e638d96e053247cf404', -- Monty
+                    'fcdc42af066d65fb655ab6d6f4709507dd29a0d38732bf60b3cbbdb1be6f7d24', -- Jannic
+                    '8672f3f07594d0b078780470f416580139ca4cf7c0984aeeb718abdbe2d14196', -- Sirius
 					'342522f118b92ebeb5a8c9c9a2269faa886a14a798190fe5730cfff513a79dd3', -- vegms
 					'f5790bb64dd695f5f87469c47ecda11e218a35f5da807367110d1cb6354eb005', -- Sellerie
 				},
@@ -294,41 +196,41 @@
 			beta = {
 				name = 'beta',
 				mirrors = {
-                                        'http://updates.freifunk-aachen.de/from-2019.1.x/beta/sysupgrade',
-                                        'http://updates.ffac.rocks/from-2019.1.x/beta/sysupgrade',
-                                        'http://updates.aachen.freifunk.net/from-2019.1.x/beta/sysupgrade',
+                    'http://updates.freifunk-aachen.de/from-2019.1.x/beta/sysupgrade',
+                    'http://updates.ffac.rocks/from-2019.1.x/beta/sysupgrade',
+                    'http://updates.aachen.freifunk.net/from-2019.1.x/beta/sysupgrade',
 				},
 				good_signatures = 3,
 				pubkeys = {
 					'e1505aadd3c5674a93ff2c8596b2cb2d857b068b18f9a398a182b003a5e5040b', -- Bob (Build Server @skydisk)
 					'b34dc4f34a5a6c588f6ac41736edd1195d9f5e949f913d4cc7a4777ebbf22c9c', -- MrMM
 					'd6a35069e60afad2f4554d6609c0934e478e264e7cfbd131afeac66ba745dc02', -- Shiva
-                                        '5bdb75b8f2f290453933975ba772b94596a5dae5091a1e638d96e053247cf404', -- Monty
-                                        'fcdc42af066d65fb655ab6d6f4709507dd29a0d38732bf60b3cbbdb1be6f7d24', -- Jannic
-                                        '8672f3f07594d0b078780470f416580139ca4cf7c0984aeeb718abdbe2d14196', -- Sirius
+                    '5bdb75b8f2f290453933975ba772b94596a5dae5091a1e638d96e053247cf404', -- Monty
+                    'fcdc42af066d65fb655ab6d6f4709507dd29a0d38732bf60b3cbbdb1be6f7d24', -- Jannic
+                    '8672f3f07594d0b078780470f416580139ca4cf7c0984aeeb718abdbe2d14196', -- Sirius
 					'342522f118b92ebeb5a8c9c9a2269faa886a14a798190fe5730cfff513a79dd3', -- vegms
 					'f5790bb64dd695f5f87469c47ecda11e218a35f5da807367110d1cb6354eb005', -- Sellerie
 				},
 			},
-                        experimental = {
-                                name = 'experimental',
-                                mirrors = {
-                                        'http://updates.freifunk-aachen.de/from-2019.1.x/experimental/sysupgrade',
-                                        'http://updates.ffac.rocks/from-2019.1.x/experimental/sysupgrade',
-                                        'http://updates.aachen.freifunk.net/from-2019.1.x/experimental/sysupgrade',
+            experimental = {
+                name = 'experimental',
+                mirrors = {
+                    'http://updates.freifunk-aachen.de/from-2019.1.x/experimental/sysupgrade',
+                    'http://updates.ffac.rocks/from-2019.1.x/experimental/sysupgrade',
+                    'http://updates.aachen.freifunk.net/from-2019.1.x/experimental/sysupgrade',
 				},
-                                good_signatures = 2,
-                                pubkeys = {
+                good_signatures = 2,
+                pubkeys = {
 					'e1505aadd3c5674a93ff2c8596b2cb2d857b068b18f9a398a182b003a5e5040b', -- Bob (Build Server @skydisk)
 					'b34dc4f34a5a6c588f6ac41736edd1195d9f5e949f913d4cc7a4777ebbf22c9c', -- MrMM
 					'd6a35069e60afad2f4554d6609c0934e478e264e7cfbd131afeac66ba745dc02', -- Shiva
-                                        '5bdb75b8f2f290453933975ba772b94596a5dae5091a1e638d96e053247cf404', -- Monty
-                                        'fcdc42af066d65fb655ab6d6f4709507dd29a0d38732bf60b3cbbdb1be6f7d24', -- Jannic
-                                        '8672f3f07594d0b078780470f416580139ca4cf7c0984aeeb718abdbe2d14196', -- Sirius
+                    '5bdb75b8f2f290453933975ba772b94596a5dae5091a1e638d96e053247cf404', -- Monty
+                    'fcdc42af066d65fb655ab6d6f4709507dd29a0d38732bf60b3cbbdb1be6f7d24', -- Jannic
+                    '8672f3f07594d0b078780470f416580139ca4cf7c0984aeeb718abdbe2d14196', -- Sirius
 					'342522f118b92ebeb5a8c9c9a2269faa886a14a798190fe5730cfff513a79dd3', -- vegms
 					'f5790bb64dd695f5f87469c47ecda11e218a35f5da807367110d1cb6354eb005', -- Sellerie
-                                },
-                        },
+                },
+            },
 		},
 	},
 
@@ -353,22 +255,20 @@
  		skip = false,
  	},
 
-	authorized_keys = { '', },
-
-        ssid_changer = {
-                enabled = true,
-                switch_timeframe = 1,           -- only once every timeframe (in minutes) the SSID will change to OFFLINE 
-                                                -- set to 1440 to change once a day
-                                                -- set to 1 minute to change every time the router gets offline
-                first = 2,                      -- the first few minutes directly after reboot within which an Offline-SSID always may be activated
-                prefix = 'FF_Offline_',         -- use something short to leave space for the nodename (no '~' allowed!)
-                suffix = 'nodename',            -- generate the SSID with either 'nodename', 'mac' or to use only the prefix: 'none'
-                tq_limit_enabled = false,       -- if false, the offline SSID will only be set if there is no gateway reacheable
-                                                -- upper and lower limit to turn the offline_ssid on and off
-                                                -- in-between these two values the SSID will never be changed to prevent it from toggeling every minute.
-                tq_limit_max = 55,              -- upper limit, above that the online SSID will be used
-                tq_limit_min = 45,              -- lower limit, below that the offline SSID will be used
-        },
+    ssid_changer = {
+        enabled = true,
+        switch_timeframe = 1,           -- only once every timeframe (in minutes) the SSID will change to OFFLINE 
+                                        -- set to 1440 to change once a day
+                                        -- set to 1 minute to change every time the router gets offline
+        first = 2,                      -- the first few minutes directly after reboot within which an Offline-SSID always may be activated
+        prefix = 'FF_Offline_',         -- use something short to leave space for the nodename (no '~' allowed!)
+        suffix = 'nodename',            -- generate the SSID with either 'nodename', 'mac' or to use only the prefix: 'none'
+        tq_limit_enabled = false,       -- if false, the offline SSID will only be set if there is no gateway reacheable
+                                        -- upper and lower limit to turn the offline_ssid on and off
+                                        -- in-between these two values the SSID will never be changed to prevent it from toggeling every minute.
+        tq_limit_max = 55,              -- upper limit, above that the online SSID will be used
+        tq_limit_min = 45,              -- lower limit, below that the offline SSID will be used
+    },
 }
 
 -- /* vi: set ft=lua: */

--- a/site.mk
+++ b/site.mk
@@ -1,225 +1,339 @@
-##	gluon site.mk Freifunk Regio Aachen
-
-##	GLUON_FEATURES
-#		Specify Gluon features/packages to enable;
-#		Gluon will automatically enable a set of packages
-#		depending on the combination of features listed
+GLUON_DEPRECATED=upgrade
 
 GLUON_FEATURES := \
-	mesh-batman-adv-14 \
-	respondd \
-	autoupdater \
+        autoupdater \
 	ebtables-filter-multicast \
 	ebtables-filter-ra-dhcp \
-	web-wizard \
+	mesh-batman-adv-15 \
+	mesh-vpn-fastd \
+	radv-filterd \
+	respondd \
+	status-page \
 	web-advanced \
 	web-mesh-vpn-fastd \
 	web-private-wifi \
-	mesh-vpn-fastd \
-	radv-filterd \
-	status-page
-
-##	GLUON_SITE_PACKAGES
-#		Specify additional Gluon/LEDE packages to include here;
-#		A minus sign may be prepended to remove a packages from the
-#		selection that would be enabled by default or due to the
-#		chosen feature flags
+	web-wizard
 
 GLUON_SITE_PACKAGES := \
-	-gluon-status-page \
 	ffac-status-page \
-	gluon-weeklyreboot \
-	iwinfo \
-	haveged
-
-# add offline ssid and other wifi related packages only if the target has wifi
-INCLUDE_WIFI_EXTRAS := \
-	respondd-module-airtime \
-	eulenfunk-hotfix \
+	ffho-autoupdater-wifi-fallback \
 	gluon-ssid-changer \
-	ffho-autoupdater-wifi-fallback
+	iwinfo \
+        iptables \
+        respondd-module-airtime
 
-ifeq ($(GLUON_TARGET),ar71xx-generic)
-GLUON_SITE_PACKAGES += $(INCLUDE_WIFI_EXTRAS)
-endif
-
-ifeq ($(GLUON_TARGET),ar71xx-mikrotik)
-GLUON_SITE_PACKAGES += $(INCLUDE_WIFI_EXTRAS)
-endif
-
-ifeq ($(GLUON_TARGET),ar71xx-nand)
-GLUON_SITE_PACKAGES += $(INCLUDE_WIFI_EXTRAS)
-endif
-
-ifeq ($(GLUON_TARGET),ar71xx-tiny)
-GLUON_SITE_PACKAGES += $(INCLUDE_WIFI_EXTRAS) \
-	zram-swap
-endif
-
-ifeq ($(GLUON_TARGET),ipq40xx)
-GLUON_SITE_PACKAGES += $(INCLUDE_WIFI_EXTRAS)
-endif
-
-ifeq ($(GLUON_TARGET),ipq806x)
-GLUON_SITE_PACKAGES += $(INCLUDE_WIFI_EXTRAS)
-endif
-
-ifeq ($(GLUON_TARGET),mpc85xx-generic)
-GLUON_SITE_PACKAGES += $(INCLUDE_WIFI_EXTRAS)
-endif
-
-ifeq ($(GLUON_TARGET),mpc85xx-p1020)
-GLUON_SITE_PACKAGES += $(INCLUDE_WIFI_EXTRAS)
-endif
-
-ifeq ($(GLUON_TARGET),mvebu-cortexa9)
-GLUON_SITE_PACKAGES += $(INCLUDE_WIFI_EXTRAS)
-endif
-
-ifeq ($(GLUON_TARGET),ramips-mt7620)
-GLUON_SITE_PACKAGES += $(INCLUDE_WIFI_EXTRAS)
-endif
-
-ifeq ($(GLUON_TARGET),ramips-mt7621)
-GLUON_SITE_PACKAGES += $(INCLUDE_WIFI_EXTRAS)
-endif
-
-ifeq ($(GLUON_TARGET),ramips-mt76x8)
-GLUON_SITE_PACKAGES += $(INCLUDE_WIFI_EXTRAS)
-endif
-
-ifeq ($(GLUON_TARGET),ramips-rt305x)
-GLUON_SITE_PACKAGES += $(INCLUDE_WIFI_EXTRAS)
-endif
-
-ifeq ($(GLUON_TARGET),ramips-rt305x)
-GLUON_SITE_PACKAGES += $(INCLUDE_WIFI_EXTRAS)
-endif
-
-ifeq ($(GLUON_TARGET),sunxi-cortexa7)
-GLUON_SITE_PACKAGES += $(INCLUDE_WIFI_EXTRAS)
-endif
-
-# add addition network drivers and usb stuff only to targes where disk space does not matter.
-ifeq ($(GLUON_TARGET),x86-generic)
-GLUON_SITE_PACKAGES += \
-        kmod-usb-core \
-        kmod-usb-ohci-pci \
-        kmod-usb2 \
-        kmod-usb-hid \
-        kmod-usb-net \
-        kmod-usb-net-asix \
-        kmod-usb-net-dm9601-ether \
-        kmod-sky2 \
-        kmod-r8169 \
-        kmod-forcedeth \
-        kmod-8139too \
-	kmod-atl2 \
-	kmod-igb \
-	kmod-button-hotplug
-endif
-
-ifeq ($(GLUON_TARGET),x86-64)
-GLUON_SITE_PACKAGES += \
-        kmod-usb-core \
-        kmod-usb-ohci-pci \
-        kmod-usb2 \
-        kmod-usb-hid \
-        kmod-usb-net \
-        kmod-usb-net-asix \
-        kmod-usb-net-dm9601-ether \
-        kmod-sky2 \
-        kmod-r8169 \
-        kmod-forcedeth \
-        kmod-8139too \
-	kmod-atl2 \
-	kmod-igb \
-	kmod-button-hotplug
-endif
-
-ifeq ($(GLUON_TARGET),x86-geode)
-GLUON_SITE_PACKAGES += \
-        kmod-usb-core \
-        kmod-usb-ohci-pci \
-        kmod-usb2 \
-        kmod-usb-hid \
-        kmod-usb-net \
-        kmod-usb-net-asix \
-        kmod-usb-net-dm9601-ether \
-        kmod-sky2 \
-        kmod-r8169 \
-        kmod-forcedeth \
-        kmod-8139too \
-        kmod-atl2 \
-        kmod-igb \
-	kmod-button-hotplug
-endif
-
-# Add offline ssid, network drivers and usb stuff to raspberry and banana pi images
-
-ifeq ($(GLUON_TARGET),brcm2708-bcm2708)
-GLUON_SITE_PACKAGES += $(INCLUDE_WIFI_EXTRAS) \
-        kmod-usb-core \
-        kmod-usb2 \
-        kmod-usb-hid \
-        kmod-usb-net \
-        kmod-usb-net-asix \
-        kmod-usb-net-dm9601-ether
-endif
-
-ifeq ($(GLUON_TARGET),brcm2708-bcm2709)
-GLUON_SITE_PACKAGES += \
-GLUON_SITE_PACKAGES += $(INCLUDE_WIFI_EXTRAS) \
-        kmod-usb-core \
-        kmod-usb2 \
-        kmod-usb-hid \
-        kmod-usb-net \
-        kmod-usb-net-asix \
-        kmod-usb-net-dm9601-ether
-endif
-
-ifeq ($(GLUON_TARGET),brcm2708-bcm2710)
-GLUON_SITE_PACKAGES += $(INCLUDE_WIFI_EXTRAS) \
-        kmod-usb-core \
-        kmod-usb2 \
-        kmod-usb-hid \
-        kmod-usb-net \
-        kmod-usb-net-asix \
-        kmod-usb-net-dm9601-ether
-endif
-
-##	DEFAULT_GLUON_RELEASE
-#		version string to use for images
-#		gluon relies on
-#			opkg compare-versions "$1" '>>' "$2"
-#		to decide if a version is newer or not.
-
-DEFAULT_GLUON_RELEASE := 2019.1.3-1~exp$(shell date '+%Y%m%d')
-
-DEFAULT_GLUON_CHECKOUT := v2019.1.3
-
-##	GLUON_RELEASE
-#		call make with custom GLUON_RELEASE flag, to use your own release version scheme.
-#		e.g.:
-#			$ make images GLUON_RELEASE=23.42+5
-#		would generate images named like this:
-#			gluon-ff%site_code%-23.42+5-%router_model%.bin
+DEFAULT_GLUON_RELEASE := 2021.1-1~exp$(shell date '+%Y%m%d%H')
 
 # Allow overriding the release number from the command line
 GLUON_RELEASE ?= $(DEFAULT_GLUON_RELEASE)
+
+DEFAULT_GLUON_CHECKOUT := v2021.1
+
 GLUON_CHECKOUT ?= $(DEFAULT_GLUON_CHECKOUT)
 
-# Default priority for updates.
 GLUON_PRIORITY ?= 0
 
-# Region code required for some images; supported values: us eu
 GLUON_REGION ?= eu
 
 # Languages to include
 GLUON_LANGS ?= en de
 
-# Select ath10k Firmware for adhoc
+# Additional package list generated by contrib/genpkglist.py
 
-GLUON_WLAN_MESH ?= 11s
+INCLUDE_USB := \
+    usbutils
 
-GLUON_DEPRECATED ?= full
+EXCLUDE_USB := \
+    -usbutils
+
+INCLUDE_USB_HID := \
+    kmod-usb-hid \
+    kmod-hid-generic
+
+EXCLUDE_USB_HID := \
+    -kmod-usb-hid \
+    -kmod-hid-generic
+
+INCLUDE_USB_SERIAL := \
+    kmod-usb-serial \
+    kmod-usb-serial-ftdi \
+    kmod-usb-serial-pl2303
+
+EXCLUDE_USB_SERIAL := \
+    -kmod-usb-serial \
+    -kmod-usb-serial-ftdi \
+    -kmod-usb-serial-pl2303
+
+INCLUDE_USB_STORAGE := \
+    block-mount \
+    blkid \
+    kmod-fs-ext4 \
+    kmod-fs-ntfs \
+    kmod-fs-vfat \
+    kmod-usb-storage \
+    kmod-usb-storage-extras \
+    kmod-usb-storage-uas \
+    kmod-nls-base \
+    kmod-nls-cp1250 \
+    kmod-nls-cp437 \
+    kmod-nls-cp850 \
+    kmod-nls-cp852 \
+    kmod-nls-iso8859-1 \
+    kmod-nls-iso8859-13 \
+    kmod-nls-iso8859-15 \
+    kmod-nls-iso8859-2 \
+    kmod-nls-utf8
+
+EXCLUDE_USB_STORAGE := \
+    -block-mount \
+    -blkid \
+    -kmod-fs-ext4 \
+    -kmod-fs-ntfs \
+    -kmod-fs-vfat \
+    -kmod-usb-storage \
+    -kmod-usb-storage-extras \
+    -kmod-usb-storage-uas \
+    -kmod-nls-base \
+    -kmod-nls-cp1250 \
+    -kmod-nls-cp437 \
+    -kmod-nls-cp850 \
+    -kmod-nls-cp852 \
+    -kmod-nls-iso8859-1 \
+    -kmod-nls-iso8859-13 \
+    -kmod-nls-iso8859-15 \
+    -kmod-nls-iso8859-2 \
+    -kmod-nls-utf8
+
+INCLUDE_USB_NET := \
+    kmod-mii \
+    kmod-usb-net \
+    kmod-usb-net-asix \
+    kmod-usb-net-asix-ax88179 \
+    kmod-usb-net-cdc-eem \
+    kmod-usb-net-cdc-ether \
+    kmod-usb-net-cdc-subset \
+    kmod-usb-net-dm9601-ether \
+    kmod-usb-net-hso \
+    kmod-usb-net-ipheth \
+    kmod-usb-net-mcs7830 \
+    kmod-usb-net-pegasus \
+    kmod-usb-net-rndis \
+    kmod-usb-net-rtl8152 \
+    kmod-usb-net-smsc95xx
+
+EXCLUDE_USB_NET := \
+    -kmod-mii \
+    -kmod-usb-net \
+    -kmod-usb-net-asix \
+    -kmod-usb-net-asix-ax88179 \
+    -kmod-usb-net-cdc-eem \
+    -kmod-usb-net-cdc-ether \
+    -kmod-usb-net-cdc-subset \
+    -kmod-usb-net-dm9601-ether \
+    -kmod-usb-net-hso \
+    -kmod-usb-net-ipheth \
+    -kmod-usb-net-mcs7830 \
+    -kmod-usb-net-pegasus \
+    -kmod-usb-net-rndis \
+    -kmod-usb-net-rtl8152 \
+    -kmod-usb-net-smsc95xx
+
+INCLUDE_PCI := \
+    pciutils
+
+EXCLUDE_PCI := \
+    -pciutils
+
+INCLUDE_PCI_NET := \
+    kmod-bnx2
+
+EXCLUDE_PCI_NET := \
+    -kmod-bnx2
+
+INCLUDE_TLS := \
+    ca-bundle \
+    libustream-openssl
+
+EXCLUDE_TLS := \
+    -ca-bundle \
+    -libustream-openssl
+
+ifeq ($(GLUON_TARGET),ar71xx-generic)
+    GLUON_SITE_PACKAGES += $(INCLUDE_TLS) $(INCLUDE_USB) $(INCLUDE_USB_NET) $(INCLUDE_USB_SERIAL) $(INCLUDE_USB_STORAGE)
+
+    GLUON_allnet-all0315n_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_avm-fritz-wlan-repeater-300e_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_avm-fritz-wlan-repeater-450e_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_d-link-dap-1330-rev-a1_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_d-link-dir-825-rev-b1_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_meraki-mr12_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_meraki-mr16_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_ocedo-koala_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_openmesh-mr1750_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_openmesh-mr600_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_openmesh-mr900_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_openmesh-om2p_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_openmesh-om5p_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_openmesh-om5p-ac_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_tp-link-cpe210-v1_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_tp-link-cpe210-v2_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_tp-link-cpe210-v3_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_tp-link-cpe510-v1_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_tp-link-wbs210-v1_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_tp-link-wbs510-v1_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_tp-link-archer-c25-v1_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_tp-link-archer-c58-v1_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_tp-link-archer-c60-v1_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_tp-link-archer-c60-v2_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_tp-link-re355_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_tp-link-re450_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_ubiquiti-airgateway_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_ubiquiti-airgateway-pro_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_ubiquiti-bullet-m_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_ubiquiti-rocket-m_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_ubiquiti-nanostation-m_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_ubiquiti-loco-m-xw_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_ubiquiti-nanostation-m-xw_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_ubiquiti-rocket-m-xw_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_ubiquiti-rocket-m-ti_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_ubiquiti-unifi_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_ubiquiti-unifi-ap-pro_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_ubiquiti-unifiap-outdoor_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_ubiquiti-unifiap-outdoor+_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_ubiquiti-ls-sr71_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_ubiquiti-unifi-ac-lite_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_ubiquiti-unifi-ac-lr_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_ubiquiti-unifi-ac-pro_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_ubiquiti-unifi-ac-mesh_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_linksys-wrt160nl_SITE_PACKAGES += $(EXCLUDE_TLS) $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_tp-link-tl-wr710n-v1_SITE_PACKAGES += $(EXCLUDE_TLS) $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_tp-link-tl-wr710n-v2.1_SITE_PACKAGES += $(EXCLUDE_TLS) $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_tp-link-tl-wr842n-nd-v1_SITE_PACKAGES += $(EXCLUDE_TLS) $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_tp-link-tl-wr842n-nd-v2_SITE_PACKAGES += $(EXCLUDE_TLS) $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_tp-link-tl-wr1043n-nd-v1_SITE_PACKAGES += $(EXCLUDE_TLS) $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_ubiquiti-airrouter_SITE_PACKAGES += $(EXCLUDE_TLS) $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+endif
+
+# no pkglists for target ar71xx-mikrotik
+
+
+ifeq ($(GLUON_TARGET),ar71xx-nand)
+    GLUON_SITE_PACKAGES += $(INCLUDE_TLS) $(INCLUDE_USB) $(INCLUDE_USB_NET) $(INCLUDE_USB_SERIAL) $(INCLUDE_USB_STORAGE)
+
+endif
+
+# no pkglists for target ar71xx-tiny
+
+
+ifeq ($(GLUON_TARGET),ath79-generic)
+    GLUON_SITE_PACKAGES += $(INCLUDE_TLS) $(INCLUDE_USB) $(INCLUDE_USB_NET) $(INCLUDE_USB_SERIAL) $(INCLUDE_USB_STORAGE)
+
+    GLUON_devolo-wifi-pro-1200e_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_devolo-wifi-pro-1200i_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_devolo-wifi-pro-1750c_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_devolo-wifi-pro-1750i_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_devolo-wifi-pro-1750x_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_ocedo-raccoon_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_tp-link-archer-c6-v2_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_tp-link-cpe220-v3_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+endif
+
+ifeq ($(GLUON_TARGET),brcm2708-bcm2708)
+    GLUON_SITE_PACKAGES += $(INCLUDE_TLS) $(INCLUDE_USB) $(INCLUDE_USB_HID) $(INCLUDE_USB_NET) $(INCLUDE_USB_SERIAL) $(INCLUDE_USB_STORAGE)
+
+endif
+
+ifeq ($(GLUON_TARGET),brcm2708-bcm2709)
+    GLUON_SITE_PACKAGES += $(INCLUDE_TLS) $(INCLUDE_USB) $(INCLUDE_USB_HID) $(INCLUDE_USB_NET) $(INCLUDE_USB_SERIAL) $(INCLUDE_USB_STORAGE)
+
+endif
+
+ifeq ($(GLUON_TARGET),brcm2708-bcm2710)
+    GLUON_SITE_PACKAGES += $(INCLUDE_TLS) $(INCLUDE_USB) $(INCLUDE_USB_HID) $(INCLUDE_USB_NET) $(INCLUDE_USB_SERIAL) $(INCLUDE_USB_STORAGE)
+
+endif
+
+ifeq ($(GLUON_TARGET),ipq40xx-generic)
+    GLUON_SITE_PACKAGES += $(INCLUDE_TLS) $(INCLUDE_USB) $(INCLUDE_USB_NET) $(INCLUDE_USB_SERIAL) $(INCLUDE_USB_STORAGE)
+
+endif
+
+ifeq ($(GLUON_TARGET),ipq806x-generic)
+    GLUON_SITE_PACKAGES += $(INCLUDE_TLS) $(INCLUDE_USB) $(INCLUDE_USB_NET) $(INCLUDE_USB_SERIAL) $(INCLUDE_USB_STORAGE)
+
+endif
+
+ifeq ($(GLUON_TARGET),lantiq-xrx200)
+    GLUON_SITE_PACKAGES += $(INCLUDE_TLS) $(INCLUDE_USB) $(INCLUDE_USB_NET) $(INCLUDE_USB_SERIAL) $(INCLUDE_USB_STORAGE)
+
+endif
+
+ifeq ($(GLUON_TARGET),lantiq-xway)
+    GLUON_SITE_PACKAGES += $(INCLUDE_TLS) $(INCLUDE_USB) $(INCLUDE_USB_NET) $(INCLUDE_USB_SERIAL) $(INCLUDE_USB_STORAGE)
+
+endif
+
+ifeq ($(GLUON_TARGET),mpc85xx-generic)
+    GLUON_SITE_PACKAGES += $(INCLUDE_TLS) $(INCLUDE_USB) $(INCLUDE_USB_NET) $(INCLUDE_USB_SERIAL) $(INCLUDE_USB_STORAGE)
+
+endif
+
+ifeq ($(GLUON_TARGET),mpc85xx-p1020)
+    GLUON_SITE_PACKAGES += $(INCLUDE_TLS) $(INCLUDE_USB) $(INCLUDE_USB_NET) $(INCLUDE_USB_SERIAL) $(INCLUDE_USB_STORAGE)
+
+endif
+
+ifeq ($(GLUON_TARGET),mvebu-cortexa9)
+    GLUON_SITE_PACKAGES += $(INCLUDE_TLS) $(INCLUDE_USB) $(INCLUDE_USB_NET) $(INCLUDE_USB_SERIAL) $(INCLUDE_USB_STORAGE)
+
+endif
+
+ifeq ($(GLUON_TARGET),ramips-mt7620)
+    GLUON_SITE_PACKAGES += $(INCLUDE_TLS) $(INCLUDE_USB) $(INCLUDE_USB_NET) $(INCLUDE_USB_SERIAL) $(INCLUDE_USB_STORAGE)
+
+endif
+
+ifeq ($(GLUON_TARGET),ramips-mt7621)
+    GLUON_SITE_PACKAGES += $(INCLUDE_TLS) $(INCLUDE_USB) $(INCLUDE_USB_NET) $(INCLUDE_USB_SERIAL) $(INCLUDE_USB_STORAGE)
+
+    GLUON_netgear-ex6150_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_ubnt-erx_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_ubnt-erx-sfp_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+endif
+
+ifeq ($(GLUON_TARGET),ramips-mt76x8)
+    GLUON_SITE_PACKAGES += $(INCLUDE_TLS) $(INCLUDE_USB) $(INCLUDE_USB_NET) $(INCLUDE_USB_SERIAL) $(INCLUDE_USB_STORAGE)
+
+    GLUON_cudy-wr1000_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_gl.inet-vixmini_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_tp-link-archer-c50-v3_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_tp-link-archer-c50-v4_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_tp-link-tl-wa801nd-v5_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_tp-link-tl-wr841n-v13_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+endif
+
+# no pkglists for target ramips-rt305x
+
+
+ifeq ($(GLUON_TARGET),sunxi-cortexa7)
+    GLUON_SITE_PACKAGES += $(INCLUDE_TLS) $(INCLUDE_USB) $(INCLUDE_USB_NET) $(INCLUDE_USB_SERIAL) $(INCLUDE_USB_STORAGE)
+
+endif
+
+ifeq ($(GLUON_TARGET),x86-64)
+    GLUON_SITE_PACKAGES += $(INCLUDE_PCI) $(INCLUDE_PCI_NET) $(INCLUDE_TLS) $(INCLUDE_USB) $(INCLUDE_USB_NET) $(INCLUDE_USB_SERIAL) $(INCLUDE_USB_STORAGE)
+
+endif
+
+ifeq ($(GLUON_TARGET),x86-generic)
+    GLUON_SITE_PACKAGES += $(INCLUDE_PCI) $(INCLUDE_PCI_NET) $(INCLUDE_TLS) $(INCLUDE_USB) $(INCLUDE_USB_NET) $(INCLUDE_USB_SERIAL) $(INCLUDE_USB_STORAGE)
+
+endif
+
+ifeq ($(GLUON_TARGET),x86-geode)
+    GLUON_SITE_PACKAGES += $(INCLUDE_PCI) $(INCLUDE_PCI_NET) $(INCLUDE_TLS) $(INCLUDE_USB) $(INCLUDE_USB_NET) $(INCLUDE_USB_SERIAL) $(INCLUDE_USB_STORAGE)
+
+endif
+
+# no pkglists for target x86-legacy
+

--- a/site.mk
+++ b/site.mk
@@ -1,7 +1,7 @@
 GLUON_DEPRECATED=upgrade
 
 GLUON_FEATURES := \
-        autoupdater \
+    autoupdater \
 	ebtables-filter-multicast \
 	ebtables-filter-ra-dhcp \
 	mesh-batman-adv-15 \
@@ -19,8 +19,8 @@ GLUON_SITE_PACKAGES := \
 	ffho-autoupdater-wifi-fallback \
 	gluon-ssid-changer \
 	iwinfo \
-        iptables \
-        respondd-module-airtime
+    iptables \
+    respondd-module-airtime
 
 DEFAULT_GLUON_RELEASE := 2021.1-1~exp$(shell date '+%Y%m%d%H')
 


### PR DESCRIPTION
Good day.
I just updated Gluon and the site configuration to be up to date with the upstream changes. We might want to create a v2021.1 branch since the current merge still points to the v2019.1.x base. Feel free to leave some feedback! :)

I changed gluon-mesh-batman-adv-14 to gluon-mesh-batman-adv-15, as the former is deprecated since the 2014.4 release.