### PR TITLE
Rename mesh-wifi to ffac-bat4-mesh

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -48,7 +48,7 @@
 			ssid = 'Freifunk',
 		},
 		mesh = {
-			id = 'ffac-bat5-mesh',
+			id = 'ffac-bat4-mesh',
 			mcast_rate = 12000,
 		},
 	},
@@ -60,7 +60,7 @@
 			ssid = 'Freifunk',
 		},
 		mesh = {
-			id = 'ffac-bat5-mesh',
+			id = 'ffac-bat4-mesh',
 			mcast_rate = 12000,
 		},
 	},


### PR DESCRIPTION
This is just a draft to prepare the last migration to the new wifi name for our mesh network.