### PR TITLE
Remove language in map url link in gluon-banner config

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -338,7 +338,7 @@
 
 	custom_banner = {
 		enabled     = true,                         -- optional (enabled by default)
-		map_url     = 'https://map.aachen.freifunk.net/#!/de/map/',  -- optional (skipped by default)
+		map_url     = 'https://map.aachen.freifunk.net/#!/',  -- optional (skipped by default)
 		contact_url = 'https://freifunk-aachen.de/kontakt/', -- optional (skipped by default)
 	},
 }


### PR DESCRIPTION
As noted by FFMUC this should work as well - the trailing slash was missing

See https://github.com/freifunkMUC/site-ffm/pull/464